### PR TITLE
Numerics and crypto test suites

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -12,11 +12,19 @@ GOMAXPROCS=1 CI=true ginkgo --cover core/collection/buffer \
                                     core/vm/mul            \
                                     core/vm/open           \
                                     core/vm/rng            \
-                                    core/vm
+                                    core/vm                \
+                                    core/vss/algebra       \
+                                    core/vss/pedersen      \
+                                    core/vss/shamir        \
+                                    core/vss
 covermerge core/collection/buffer/buffer.coverprofile \
            core/collection/stack/stack.coverprofile   \
            core/vm/mul/mul.coverprofile               \
            core/vm/open/open.coverprofile             \
            core/vm/rng/rng.coverprofile               \
            core/vm/vm.coverprofile                    \
+           core/vss/algebra.coverprofile              \
+           core/vss/pedersen.coverprofile             \
+           core/vss/shamir.coverprofile               \
+           core/vss
            > oro.coverprofile

--- a/.travis.sh
+++ b/.travis.sh
@@ -23,8 +23,8 @@ covermerge core/collection/buffer/buffer.coverprofile \
            core/vm/open/open.coverprofile             \
            core/vm/rng/rng.coverprofile               \
            core/vm/vm.coverprofile                    \
-           core/vss/algebra.coverprofile              \
-           core/vss/pedersen.coverprofile             \
-           core/vss/shamir.coverprofile               \
+           core/vss/algebra/algebra.coverprofile      \
+           core/vss/pedersen/pedersen.coverprofile    \
+           core/vss/shamir/shamir.coverprofile        \
            core/vss
            > oro.coverprofile

--- a/.travis.sh
+++ b/.travis.sh
@@ -26,5 +26,5 @@ covermerge core/collection/buffer/buffer.coverprofile \
            core/vss/algebra/algebra.coverprofile      \
            core/vss/pedersen/pedersen.coverprofile    \
            core/vss/shamir/shamir.coverprofile        \
-           core/vss
+           core/vss/vss.coverprofile                  \
            > oro.coverprofile

--- a/core/vm/vm_test.go
+++ b/core/vm/vm_test.go
@@ -746,7 +746,7 @@ var _ = Describe("Virtual Machine", func() {
 							tableBits := []struct {
 								bits int
 							}{
-								{1}, {2}, {3}, {6}, {7}, {14}, {15}, {30}, {31},
+								{1}, {2}, {3}, {4}, {7}, {8}, {15}, {16},
 							}
 							for _, entryBits := range tableBits {
 								entryBits := entryBits

--- a/core/vss/algebra/element.go
+++ b/core/vss/algebra/element.go
@@ -1,7 +1,6 @@
 package algebra
 
 import (
-	"fmt"
 	"math/big"
 )
 
@@ -19,10 +18,6 @@ func (lhs FpElement) Value() *big.Int {
 
 // FpElements is a slice.
 type FpElements []FpElement
-
-func (lhs FpElement) String() string {
-	return fmt.Sprintf("{p: %v, v: %v}", lhs.prime, lhs.value)
-}
 
 // Field returns the field that the element is in.
 func (lhs FpElement) Field() Fp {

--- a/core/vss/algebra/element_test.go
+++ b/core/vss/algebra/element_test.go
@@ -301,7 +301,7 @@ var _ = Describe("Finite field Elements", func() {
 					expected := big.NewInt(0).Add(lhs, rhs)
 					expected.Mod(expected, prime)
 
-					Expect(field.NewInField(lhs).Add(field.NewInField(rhs)).Eq(field.NewInField(expected))).To(BeTrue())
+					Expect(field.NewInField(lhs).Add(field.NewInField(rhs)).Value().Cmp(expected)).To(Equal(0))
 				}
 			},
 				PrimeEntries...,

--- a/core/vss/algebra/polynomial_test.go
+++ b/core/vss/algebra/polynomial_test.go
@@ -1,7 +1,6 @@
 package algebra_test
 
 import (
-	"log"
 	"math/big"
 	"math/rand"
 
@@ -170,9 +169,6 @@ var _ = Describe("Polynomial", func() {
 					poly := new(Polynomial)
 
 					Expect(func() { *poly = NewRandomPolynomial(field, degree, secret) }).ToNot(Panic())
-					if prime.Cmp(big.NewInt(2)) == 0 {
-						log.Printf("secret: %v, poly: %+v", secret, *poly)
-					}
 					Expect(poly.Evaluate(field.NewInField(big.NewInt(0))).Eq(secret)).To(BeTrue())
 				}
 

--- a/core/vss/shamir/shamir_test.go
+++ b/core/vss/shamir/shamir_test.go
@@ -27,6 +27,23 @@ var _ = Describe("Shamir secret sharing", func() {
 		return uint(r)
 	}
 
+	Context("when accessing the index and value", func() {
+		DescribeTable("it should get the right values", func(prime *big.Int) {
+			field := NewField(prime)
+
+			for i := 0; i < Trials; i++ {
+				value := field.Random()
+				index := rand.Uint64()
+				share := New(index, value)
+
+				Expect(share.Value().Eq(value)).To(BeTrue())
+				Expect(share.Index()).To(Equal(index))
+			}
+		},
+			PrimeEntries...,
+		)
+	})
+
 	Context("when splitting a secret into shares", func() {
 		DescribeTable("it should panic if n is too small", func(prime *big.Int) {
 			field := NewField(prime)

--- a/core/vss/vss_test.go
+++ b/core/vss/vss_test.go
@@ -75,9 +75,10 @@ var _ = Describe("Verifiable secret sharing", func() {
 		entry := entry
 
 		Context("when creating verifiable shares", func() {
+			fp := algebra.NewField(entry.p)
 			g := algebra.NewFpElement(entry.g, entry.p)
 			h := algebra.NewFpElement(entry.h, entry.p)
-			ped := pedersen.New(g, h)
+			ped := pedersen.New(g, h, fp)
 
 			It("should panic when there are no commitments", func() {
 				field := algebra.NewField(entry.q)


### PR DESCRIPTION
**Description**

This PR enables the test suites in the `vss` package. It includes tests for:

1. Algebra and fields
2. Pedersen commitments
3. Shamir's secret sharing
4. Verifiable secret sharing

**Motivation**

These test were previously disabled due to a compilation issue. It has been resolved, so the test suite has been enabled again.

**Unresolved Issues**

Algebra has not been optimised yet.